### PR TITLE
Updates to documentation, more guidance in error messages, other misc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-02-16]
+
+### Added
+- Added ability to manually set and unset lanes that are loaded in toolhead
+- Added braking to n20 when stopping them. This was advised to implement from Isik to hopefully help reduce backfeeding from motors into MCU board when in coast mode
+- Added default temperature value to default_material_temps list instead of using min_temp_val + 5
+- Added check for printing for LANE_MOVE, HUB_LOAD and LANE_UNLOAD macros
+- Added variable for prep done so save_vars function is not called before running prep function which would override the variables file before PREP could run
+- Added more guidance to error messages when errors happen during TOOL_LOAD and TOOL_UNLOAD
+- Added helper function to get loaded lane for current extruder, help move the code towards working with multiple extruders
+- Added debounce logic when triggering prep sensor so that it does not run more than once
+- Added variable speed to LANE_MOVE move, run faster for distance over 200
+- Added printout when trying to load and load sensor is already triggered
+- Added more printout to let user know when calibration is done
+- Added printout when trying to unload but no lane is loaded
+
+### Changed
+- Updated documentation
+
+### Fixed
+- Fixed error in prep when there are multiple extruders
+- Fixed error when hub was not defined
+
 ## [2025-02-13]
 
 ### Added

--- a/config/AFC.cfg
+++ b/config/AFC.cfg
@@ -12,11 +12,11 @@ short_moves_speed: 50           # mm/s. Default value is 50mm/s.
 short_moves_accel: 300          # mm/s². Default value is 300mm/s².
 short_move_dis: 10              # Move distance for failsafe moves. Default is 10mm.
 
-# global_print_current: 0.6     # Uncomment to set stepper motors to a lower current while printing
+#global_print_current: 0.6       # Uncomment to set stepper motors to a lower current while printing
                                 # This value can also be set per stepper with print_current: 0.6
-# enable_sensors_in_gui: True    # Uncomment to show all sensor switches as filament sensors in mainsail/fluidd gui
-                                 # this can also be set at individual levels in your config file
-default_material_temps: PLA:210, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
+#enable_sensors_in_gui: True     # Uncomment to show all sensor switches as filament sensors in mainsail/fluidd gui
+                                # this can also be set at individual levels in your config file
+default_material_temps: default: 235, PLA:210, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
                                                   # Material needs to be either manually set or uses material from spoolman if extruder temp is not
                                                   # set in spoolman. Follow current format to add more
 load_to_hub: True               # Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
@@ -27,9 +27,9 @@ assisted_unload: True           # If True, the unload retract is assisted to pre
 #--=================================================================================-
 #------- TRSYNC Values --------------------------------------------------------------
 #--=================================================================================-
-# trsync_update: True           # Uncomment this value to update Klipper's trsync value automatically
-# trsync_timeout: 0.05          # Uncomment this value if timeout needs to be greater than the default of 0.05
-# trsync_single_timeout: 0.250  # Uncomment this value if single_timeout needs to be greater than the default of 0.250
+#trsync_update: True           # Uncomment this value to update Klipper's trsync value automatically
+#trsync_timeout: 0.05          # Uncomment this value if timeout needs to be greater than the default of 0.05
+#trsync_single_timeout: 0.250  # Uncomment this value if single_timeout needs to be greater than the default of 0.250
 
 #--=================================================================================-
 #------- Pause/Resume ---------------------------------------------------------------

--- a/docs/CONFIGURATION_OPTIONS.md
+++ b/docs/CONFIGURATION_OPTIONS.md
@@ -32,6 +32,7 @@
 - `short_moves_accel` (default: `400`): Acceleration in mm/s squared when doing short moves
 - `short_move_dis` (default: `10`): Move distance in mm for failsafe moves.
 - `max_move_dis` (default: `999999`): Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
+- `n20_break_delay_time` (default: `0.200`): Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
 - `tool_max_unload_attempts` (default: `2`): Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
 - `tool_max_load_checks` (default: `4`): Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
 - `z_hop` (default: `0`): Height to move up before and after a tool change completes
@@ -41,21 +42,36 @@
 - `global_print_current` (default: `None`): Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
 - `enable_sensors_in_gui` (default: `False`): Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
 - `load_to_hub` (default: `True`): Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
+- `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
 - `trsync_update` (default: `False`): Set to true to enable updating trsync value in klipper mcu. Enabling this and updating the timeouts can help with Timer Too Close(TTC) errors
 - `trsync_timeout` (default: `0.05`): Timeout value to update in klipper mcu. Klippers default value is 0.025
 - `trsync_single_timeout` (default: `0.5`): Single timeout value to update in klipper mcu. Klippers default value is 0.250
-- `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool
 
 ## AFC_buffer
 - `enable_sensors_in_gui` (default: `False`): Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+- `velocity` (default: `0`): Velocity for forward assist
 - `accel` (default: `0`): Error if buffer is not configured correctly
-- `velocity` (default: `0`): Set buffer velocity for forward assist.
 
 ## AFC_extruder
 - `enable_sensors_in_gui` (default: `False`): Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
 
 ## AFC_hub
+- `cut` (default: `False`): Set True if Hub cutter installed (e.g. Snappy)
+- `cut_cmd` (default: `None`): Macro to use for cut.
+- `cut_servo_name` (default: `'cut'`): Name of servo to use for cutting
+- `cut_dist` (default: `50`): How much filament to cut off (in mm).
+- `cut_clear` (default: `120`): How far the filament should retract back from the hub (in mm).
+- `cut_min_length` (default: `200`): Minimum length of filament to cut off
+- `cut_servo_pass_angle` (default: `0`): Servo angle to align the Bowden tube with the hole for loading the toolhead.
+- `cut_servo_clip_angle` (default: `160`): Servo angle for cutting the filament.
+- `cut_servo_prep_angle` (default: `75`): Servo angle to prepare the filament for cutting (aligning the exit hole).
+- `cut_confirm` (default: `0`): Set True to cut filament twice
+- `move_dis` (default: `50`): Distance to move the filament within the hub in mm.
+- `hub_clear_move_dis` (default: `25`): How far to move filament so that it's not block the hub exit
 - `assisted_retract` (default: `False`): if True, retracts are assisted to prevent loose windings on the spool
+- `afc_bowden_length` (default: `900`): Length of the Bowden tube from the hub to the toolhead sensor in mm.
+- `switch_pin` (default: `None`): Pin hub sensor it connected to
+- `enable_sensors_in_gui` (default: `False`): Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
 
 ## AFC_prep
 - `delay_time` (default: `0.1, minval=0.0`): Time to delay when moving extruders and spoolers during PREP routine
@@ -80,11 +96,13 @@
 - `short_moves_accel` (default: `None`): Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 - `short_move_dis` (default: `None`): Move distance in mm for failsafe moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 - `max_move_dis` (default: `999999`): Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
+- `n20_break_delay_time` (default: `0.200`): Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 - `dist_hub` (default: `60`): Bowden distance between Box Turtle extruder and hub
 - `park_dist` (default: `10`): Currently unused
 - `load_to_hub` (default: `True`): Fast loads filament to hub when inserted, set to False to disable. Setting here overrides global setting in AFC.cfg
 - `enable_sensors_in_gui` (default: `False`): Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
 - `sensor_to_show` (default: `None`): Set to prep to only show prep sensor, set to load to only show load sensor. Do not add if you want both prep and load sensors to show in web gui
+- `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 - `prep` (default: `None`): MCU pin for prep trigger
 - `load` (default: `None`): MCU pin load trigger
 - `afc_motor_rwd` (default: `None`): Reverse pin on MCU for spoolers
@@ -100,7 +118,6 @@
 - `assist_max_motor_rpm` (default: `500`): Max motor RPM
 - `rwd_speed_multiplier` (default: `0.5`): Multiplier to apply to rpm
 - `fwd_speed_multiplier` (default: `0.5`): Multiplier to apply to rpm
-- `assisted_unload` (default: `None`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
 
 ## AFC_BoxTurtle
 - `hub` (default: `None`): Hub name(AFC_hub) that belongs to this unit, can be overridden in AFC_stepper section
@@ -120,6 +137,7 @@
 - `short_move_dis` (default: `400`): Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
 - `max_move_dis` (default: `999999`): Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
 - `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
+- `n20_break_delay_time` (default: `0.200`): Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
 
 ## AFC_NightOwl
 - `hub` (default: `None`): Hub name(AFC_hub) that belongs to this unit, can be overridden in AFC_stepper section
@@ -138,3 +156,6 @@
 - `short_moves_accel` (default: `400`): Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
 - `short_move_dis` (default: `400`): Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
 - `assisted_unload` (default: `False`): If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
+- `n20_break_delay_time` (default: `0.200`): Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
+
+

--- a/docs/Calibration.md
+++ b/docs/Calibration.md
@@ -9,6 +9,8 @@
 The function `CALIBRATE_AFC` can be called in the console to calibrate distances.  
 _distances will be calibrated to have ~1 short move after the move distance_
 
+**NOTE: If using Turtleneck buffer please hold hold shut until filament reaches toolhead, once buffer start expanding slowly release. Doing this will keep the calibration from falsely triggering before fully reaching toolhead. Also pay attention and make sure the neck is not fully extended and triggering the advance sensor.**
+
 ### Definitions
 
 - `dist_hub` for each lane is the distance from the load switch at the extruder to the hub

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -56,3 +56,14 @@ default_material_temps: PLA:210, ABS:235, ASA:235 # Default temperature to set e
 
 ## Loading filament to hub
 For users that have a hub not located in their Box Turtle, AFC has the ability to load filament to their hub once its inserted. This is turned on by default and this will happen even if your hub is located in your Box Turtle. This can be disabled by setting `load_to_hub: False` in your `AFC.cfg` file. Also individual lanes can be turn on/off by setting `load_to_hub: True/False` under `[AFC_stepper <lane_name>]` section in your config.
+
+## Variable purge length on filament change
+AFC has the ability to purge different lengths with orcas flush volumes when doing filament changes with T(n) macros. To use this feature update your Change Filament G-Code section in your orca slicer to the following:
+
+`T[next_extruder] PURGE_LENGTH=[flush_length]`
+
+Could also be added to your PRINT_START macro with a specific length, this would be ideal for if your first filament is not currently loaded as the PURGE_LENGTH from Orca for the first change would be zero
+
+`T{initial_tool} PURGE_LENGTH=100`
+
+**NOTE: If your first filament is not currently loaded and needs to change, `PURGE_LENGTH` will be zero and the poop macro will then use `variable_purge_length_minimum` from AFC_Macro_Vars.cfg file, so make sure this is set correctly for your printer**

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -12,6 +12,18 @@ allows the option to calibrate all lanes across all units.
 Usage: ``AFC_CALIBRATION``  
 Example: ``AFC_CALIBRATION``  
 
+### AFC_RESUME
+_Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
+runs the resume script, and restores the toolhead position to the last saved position.  
+Usage: ``AFC_RESUME``  
+Example: ``AFC_RESUME``  
+
+### AFC_STATUS
+_Description_: This function generates a status message for each unit and lane, indicating the preparation,
+loading, hub, and tool states. The status message is formatted with HTML tags for display.  
+Usage: ``AFC_STATUS``  
+Example: ``AFC_STATUS``  
+
 ### ALL_CALIBRATION
 _Description_: Open a prompt to confirm calibration of all lanes in all units. Provides 'Yes' to confirm and 'Back' to
 return to the previous menu.  
@@ -27,13 +39,17 @@ the option to calibrate the Bowden length for a particular lane, if specified.
 Usage: ``CALIBRATE_AFC LANE=<lane> DISTANCE=<distance> TOLERANCE=<tolerance> BOWDEN=<lane>``  
 Example: `CALIBRATE_AFC LANE=lane1`  
 
-### SET_BOWDEN_LENGTH
-_Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
-It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
-by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
-it uses the hub of the current lane.  
-Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
-Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
+### CHANGE_TOOL
+_Description_: This function handles the tool change process. It retrieves the lane specified by the 'LANE' parameter,
+checks the filament sensor, saves the current position, and performs the tool change by unloading the
+current lane and loading the new lane.  
+Usage: ``CHANGE_TOOL LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)``  
+Example: ``CHANGE_TOOL LANE=lane1 PURGE_LENGTH=100``  
+
+### GET_TIP_FORMING
+_Description_: Shows the tip forming configuration  
+Usage: `GET_TIP_FORMING`  
+Example: `GET_TIP_FORMING`  
 
 ### HUB_CUT_TEST
 _Description_: This function tests the cutting sequence of the hub cutter for a specified lane.
@@ -41,32 +57,6 @@ It retrieves the lane specified by the 'LANE' parameter, performs the hub cut,
 and responds with the status of the operation.  
 Usage: ``HUB_CUT_TEST LANE=<lane>``  
 Example: ``HUB_CUT_TEST LANE=lane1``  
-
-### TEST
-_Description_: This function tests the assist motors of a specified lane at various speeds.
-It performs the following steps:
-1. Retrieves the lane specified by the 'LANE' parameter.
-2. Tests the assist motor at full speed, 50%, 30%, and 10% speeds.
-3. Reports the status of each test step.  
-Usage: ``TEST LANE=<lane>``  
-Example: ``TEST LANE=lane1``  
-
-### RESET_FAILURE
-_Description_: This function clears the error state of the AFC system by setting the error state to False.  
-Usage: ``RESET_FAILURE``  
-Example: ``RESET_FAILURE``  
-
-### AFC_RESUME
-_Description_: This function clears the error state of the AFC system, sets the in_toolchange flag to False,
-runs the resume script, and restores the toolhead position to the last saved position.  
-Usage: ``AFC_RESUME``  
-Example: ``AFC_RESUME``  
-
-### SET_AFC_TOOLCHANGES
-_Description_: This macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
-current tool change number when a T(n) command is called from gcode  
-Usage: ``SET_AFC_TOOLCHANGES TOOLCHANGES=<number>``  
-Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``  
 
 ### HUB_LOAD
 _Description_: This function handles the loading of a specified lane into the hub. It performs
@@ -80,65 +70,66 @@ several checks and movements to ensure the lane is properly unloaded.
 Usage: ``LANE_UNLOAD LANE=<lane>``  
 Example: ``LANE_UNLOAD LANE=lane1``  
 
-### TOOL_LOAD
-_Description_: This function handles the loading of a specified lane into the tool. It retrieves
-the lane specified by the 'LANE' parameter and calls the TOOL_LOAD method to perform
-the loading process.  
-Usage: ``TOOL_LOAD LANE=<lane>``  
-Example: ``TOOL_LOAD LANE=lane1``  
+### QUERY_BUFFER
+_Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
+distance of the current AFC stepper motor.  
+Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
+Example: `QUERY_BUFFER BUFFER=TN`  
 
-### TOOL_UNLOAD
-_Description_: This function handles the unloading of a specified lane from the tool head. It retrieves
-the lane specified by the 'LANE' parameter or uses the currently loaded lane if no parameter
-is provided, and calls the TOOL_UNLOAD method to perform the unloading process.  
-Usage: ``TOOL_UNLOAD [LANE=<lane>]``  
-Example: ``TOOL_UNLOAD LANE=lane1``  
+### RESET_AFC_MAPPING
+_Description_: This commands resets all tool lane mapping to the order that is setup in configuration.  
+Usage: `RESET_AFC_MAPPING`  
+Example: `RESET_AFC_MAPPING`  
 
-### CHANGE_TOOL
-_Description_: This function handles the tool change process. It retrieves the lane specified by the 'LANE' parameter,
-checks the filament sensor, saves the current position, and performs the tool change by unloading the
-current lane and loading the new lane.  
-Usage: ``CHANGE_TOOL LANE=<lane>``  
-Example: ``CHANGE_TOOL LANE=lane1``  
+### RESET_FAILURE
+_Description_: This function clears the error state of the AFC system by setting the error state to False.  
+Usage: ``RESET_FAILURE``  
+Example: ``RESET_FAILURE``  
 
-### AFC_STATUS
-_Description_: This function generates a status message for each unit and lane, indicating the preparation,
-loading, hub, and tool states. The status message is formatted with HTML tags for display.  
-Usage: ``AFC_STATUS``  
-Example: ``AFC_STATUS``  
+### SET_AFC_TOOLCHANGES
+_Description_: This macro can be used to set total number of toolchanges from slicer. AFC will keep track of tool changes and print out
+current tool change number when a T(n) command is called from gcode  
+Usage: ``SET_AFC_TOOLCHANGES TOOLCHANGES=<number>``  
+Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``  
 
-### UNIT_CALIBRATION
-_Description_: Open a prompt to calibrate either the distance between the extruder and the hub or the Bowden length
-for the selected unit. Provides buttons for lane calibration, Bowden length calibration, and a back option.  
-Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
-Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
+### SET_BOWDEN_LENGTH
+_Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
+It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
+by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
+it uses the hub of the current lane.  
+Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
+Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
 
-### UNIT_LANE_CALIBRATION
-_Description_: Open a prompt to calibrate the extruder-to-hub distance for each lane in the selected unit. Creates buttons
-for each lane, grouped in sets of two, and allows calibration for all lanes or individual lanes.  
-Usage: ``UNIT_LANE_CALIBRATION UNIT=<unit>``  
-Example: ``UNIT_LANE_CALIBRATION UNIT=Turtle_1``  
+### SET_BUFFER_VELOCITY
+_Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
+saved in configuration. Please update your configuration file once you find a velocity that
+works for your setup.  
+Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
+Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
 
-### UNIT_BOW_CALIBRATION
-_Description_: Open a prompt to calibrate the Bowden length for a specific lane in the selected unit. Provides buttons
-for each lane, with a note to only calibrate one lane per unit.  
-Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
-Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
+### SET_COLOR
+_Description_: This function handles changing the color of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and sets its color to the value provided by the 'COLOR' parameter.  
+Usage: ``SET_COLOR LANE=<lane> COLOR=<color>``  
+Example: ``SET_COLOR LANE=lane1 COLOR=FF0000``  
 
-### TEST_AFC_TIP_FORMING
-_Description_: Gives ability to test AFC tip forming without doing a tool change  
-Usage: `TEST_AFC_TIP_FORMING`  
-Example: `TEST_AFC_TIP_FORMING`  
+### SET_LANE_LOADED
+_Description_: This macro handles manually setting a lane loaded into the toolhead. This is useful when manually loading lanes
+during prints after AFC detects an error when loading/unloading and pauses. If there is a lane already loaded this macro 
+will also desync that lane extruder from the toolhead extruder and set its values and led appropriately.  
+Usage: ``SET_LANE_LOADED LANE=<lane>``  
+Example: ``SET_LANE_LOADED LANE=lane1``  
 
-### GET_TIP_FORMING
-_Description_: Shows the tip forming configuration  
-Usage: `GET_TIP_FORMING`  
-Example: `GET_TIP_FORMING`  
+### SET_MAP
+_Description_: This function handles changing the GCODE tool change command for a Lane.  
+Usage: ``SET_MAP LANE=<lane> MAP=<cmd>``  
+Example: ``SET_MAP LANE=lane1 MAP=T1``  
 
-### SET_TIP_FORMING
-_Description_: Sets the tip forming configuration  
-Usage: `SET_TIP_FORMING PARAMETER=VALUE ...`  
-Example: `SET_TIP_FORMING ramming_volume=20 toolchange_temp=220`  
+### SET_MATERIAL
+_Description_: This function handles changing the material of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+Usage: `SET_MATERIAL LANE=<lane> MATERIAL=<material>`  
+Example: `SET_MATERIAL LANE=lane1 MATERIAL=ABS`  
 
 ### SET_MULTIPLIER
 _Description_: This function handles the adjustment of the buffer multipliers for the turtleneck buffer.
@@ -154,41 +145,11 @@ the rotation distance to the base value.
 Usage: `SET_ROTATION_FACTOR BUFFER=<buffer_name> FACTOR=<factor>`  
 Example: `SET_ROTATION_FACTOR BUFFER=TN FACTOR=1.2`  
 
-### QUERY_BUFFER
-_Description_: Reports the current state of the buffer sensor and, if applicable, the rotation
-distance of the current AFC stepper motor.  
-Usage: `QUERY_BUFFER BUFFER=<buffer_name>`  
-Example: `QUERY_BUFFER BUFFER=TN`  
-
-### SET_BUFFER_VELOCITY
-_Description_: Allows users to tweak buffer velocity setting while printing. This setting is not
-saved in configuration. Please update your configuration file once you find a velocity that
-works for your setup.  
-Usage: `SET_BUFFER_VELOCITY BUFFER=<buffer_name> VELOCITY=<value>`  
-Example: `SET_BUFFER_VELOCITY BUFFER=TN2 VELOCITY=100`  
-
-### SET_MAP
-_Description_: This function handles changing the GCODE tool change command for a Lane.  
-Usage: ``SET_MAP LANE=<lane> MAP=<cmd>``  
-Example: ``SET_MAP LANE=lane1 MAP=T1``  
-
-### SET_COLOR
-_Description_: This function handles changing the color of a specified lane. It retrieves the lane
-specified by the 'LANE' parameter and sets its color to the value provided by the 'COLOR' parameter.  
-Usage: ``SET_COLOR LANE=<lane> COLOR=<color>``  
-Example: ``SET_COLOR LANE=lane1 COLOR=FF0000``  
-
-### SET_WEIGHT
-_Description_: This function handles changing the material of a specified lane. It retrieves the lane
-specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
-Usage: `SET_WEIGHT LANE=<lane> WEIGHT=<weight>`  
-Example: `SET_WEIGHT LANE=lane1 WEIGHT=850`  
-
-### SET_MATERIAL
-_Description_: This function handles changing the material of a specified lane. It retrieves the lane
-specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
-Usage: `SET_MATERIAL LANE=<lane> MATERIAL=<material>`  
-Example: `SET_MATERIAL LANE=lane1 MATERIAL=ABS`  
+### SET_RUNOUT
+_Description_: This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and updates its the lane to use if filament runs out by untriggering prep sensor  
+Usage: ``SET_RUNOUT LANE=<lane> RUNOUT=<lane>``  
+Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``  
 
 ### SET_SPOOL_ID
 _Description_: This function handles setting the spool ID for a specified lane. It retrieves the lane
@@ -197,17 +158,68 @@ based on the information retrieved from the Spoolman API.
 Usage: ``SET_SPOOL_ID LANE=<lane> SPOOL_ID=<spool_id>``  
 Example: ``SET_SPOOL_ID LANE=lane1 SPOOL_ID=12345``  
 
-### SET_RUNOUT
-_Description_: This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
-specified by the 'LANE' parameter and updates its the lane to use if filament is empty
-based on the information retrieved from the Spoolman API.  
-Usage: ``SET_RUNOUT LANE=<lane> RUNOUT=<lane>``  
-Example: ``SET_RUNOUT LANE=lane1 RUNOUT=lane4``  
+### SET_TIP_FORMING
+_Description_: Sets the tip forming configuration  
+Usage: `SET_TIP_FORMING PARAMETER=VALUE ...`  
+Example: `SET_TIP_FORMING ramming_volume=20 toolchange_temp=220`  
 
-### RESET_AFC_MAPPING
-_Description_: This commands resets all tool lane mapping to the order that is setup in configuration.  
-Usage: `RESET_AFC_MAPPING`  
-Example: `RESET_AFC_MAPPING`  
+### SET_WEIGHT
+_Description_: This function handles changing the material of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and sets its material to the value provided by the 'MATERIAL' parameter.  
+Usage: `SET_WEIGHT LANE=<lane> WEIGHT=<weight>`  
+Example: `SET_WEIGHT LANE=lane1 WEIGHT=850`  
+
+### TEST
+_Description_: This function tests the assist motors of a specified lane at various speeds.
+It performs the following steps:
+1. Retrieves the lane specified by the 'LANE' parameter.
+2. Tests the assist motor at full speed, 50%, 30%, and 10% speeds.
+3. Reports the status of each test step.  
+Usage: ``TEST LANE=<lane>``  
+Example: ``TEST LANE=lane1``  
+
+### TEST_AFC_TIP_FORMING
+_Description_: Gives ability to test AFC tip forming without doing a tool change  
+Usage: `TEST_AFC_TIP_FORMING`  
+Example: `TEST_AFC_TIP_FORMING`  
+
+### TOOL_LOAD
+_Description_: This function handles the loading of a specified lane into the tool. It retrieves
+the lane specified by the 'LANE' parameter and calls the TOOL_LOAD method to perform
+the loading process.  
+Usage: ``TOOL_LOAD LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)``  
+Example: ``TOOL_LOAD LANE=lane1 PURGE_LENGTH=80``  
+
+### TOOL_UNLOAD
+_Description_: This function handles the unloading of a specified lane from the tool head. It retrieves
+the lane specified by the 'LANE' parameter or uses the currently loaded lane if no parameter
+is provided, and calls the TOOL_UNLOAD method to perform the unloading process.  
+Usage: ``TOOL_UNLOAD LANE=<lane>``  
+Example: ``TOOL_UNLOAD LANE=lane1``  
+
+### UNIT_BOW_CALIBRATION
+_Description_: Open a prompt to calibrate the Bowden length for a specific lane in the selected unit. Provides buttons
+for each lane, with a note to only calibrate one lane per unit.  
+Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
+Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
+
+### UNIT_CALIBRATION
+_Description_: Open a prompt to calibrate either the distance between the extruder and the hub or the Bowden length
+for the selected unit. Provides buttons for lane calibration, Bowden length calibration, and a back option.  
+Usage: ``UNIT_CALIBRATION UNIT=<unit>``  
+Example: ``UNIT_CALIBRATION UNIT=Turtle_1``  
+
+### UNIT_LANE_CALIBRATION
+_Description_: Open a prompt to calibrate the extruder-to-hub distance for each lane in the selected unit. Creates buttons
+for each lane, grouped in sets of two, and allows calibration for all lanes or individual lanes.  
+Usage: ``UNIT_LANE_CALIBRATION UNIT=<unit>``  
+Example: ``UNIT_LANE_CALIBRATION UNIT=Turtle_1``  
+
+### UNSET_LANE_LOADED
+_Description_: Unsets current lane from AFC loaded status. Mainly this would be used if AFC thinks that there is a lane loaded into the toolhead
+but nothing is actually loaded.  
+Usage: ``UNSET_LANE_LOADED``  
+Example: ``UNSET_LANE_LOADED``  
 
 ## AFC Macros
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -39,11 +39,11 @@ class afc:
         # Registering webhooks endpoint for <ip_address>/printer/afc/status
         self.webhooks.register_endpoint("afc/status", self._webhooks_status)
 
-        self.SPOOL = self.printer.load_object(config,'AFC_spool')
-        self.ERROR = self.printer.load_object(config,'AFC_error')
-        self.FUNCTION = self.printer.load_object(config,'AFC_functions')
-        self.IDLE = self.printer.load_object(config,'idle_timeout')
-        self.gcode = self.printer.lookup_object('gcode')
+        self.SPOOL      = self.printer.load_object(config,'AFC_spool')
+        self.ERROR      = self.printer.load_object(config,'AFC_error')
+        self.FUNCTION   = self.printer.load_object(config,'AFC_functions')
+        self.IDLE       = self.printer.load_object(config,'idle_timeout')
+        self.gcode      = self.printer.lookup_object('gcode')
 
         self.gcode_move = self.printer.load_object(config, 'gcode_move')
 
@@ -53,6 +53,7 @@ class afc:
         self.error_state    = False
         self.current_state  = State.INIT
         self.spoolman       = None
+        self.prep_done      = False         # Variable used to hold of save_vars function from saving too early and overriding save before prep can be ran
 
         # Objects for everything configured for AFC
         self.units      = {}
@@ -84,6 +85,7 @@ class afc:
         self.VarFile = config.get('VarFile','../printer_data/config/AFC/') 			# Path to the variables file for AFC configuration.
         self.cfgloc = self._remove_after_last(self.VarFile,"/")
         self.default_material_temps = config.getlists("default_material_temps", None) # Default temperature to set extruder when loading/unloading lanes. Material needs to be either manually set or uses material from spoolman if extruder temp is not set in spoolman.
+        self.default_material_temps = list(self.default_material_temps)
 
         #LED SETTINGS
         self.ind_lights = None
@@ -125,6 +127,7 @@ class afc:
         self.short_moves_accel  = config.getfloat("short_moves_accel", 400)         # Acceleration in mm/s squared when doing short moves
         self.short_move_dis     = config.getfloat("short_move_dis", 10)             # Move distance in mm for failsafe moves.
         self.max_move_dis       = config.getfloat("max_move_dis", 999999)           # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves.
+        self.n20_break_delay_time   = config.getfloat("n20_break_delay_time", 0.200)# Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting.
 
         self.tool_max_unload_attempts = config.getint('tool_max_unload_attempts', 2)# Max number of attempts to unload filament from toolhead when using buffer as ramming sensor
         self.tool_max_load_checks = config.getint('tool_max_load_checks', 4)        # Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
@@ -212,6 +215,7 @@ class afc:
         self.gcode.register_command('CHANGE_TOOL',          self.cmd_CHANGE_TOOL,           desc=self.cmd_CHANGE_TOOL_help)
         self.gcode.register_command('AFC_STATUS',           self.cmd_AFC_STATUS,            desc=self.cmd_AFC_STATUS_help)
         self.gcode.register_command('SET_AFC_TOOLCHANGES',  self.cmd_SET_AFC_TOOLCHANGES,   desc=self.cmd_SET_AFC_TOOLCHANGES_help)
+        self.gcode.register_command('UNSET_LANE_LOADED',    self.cmd_UNSET_LANE_LOADED,     desc=self.cmd_UNSET_LANE_LOADED_help)
         self.current_state = State.IDLE
 
     def print_version(self):
@@ -238,7 +242,12 @@ class afc:
         :return truple : float for temperature to heat extruder to,
                          bool True if user is using min_extruder_temp value
         """
-        temp_value = self.heater.min_extrude_temp + 5
+        try:
+            # Try to get default value from list, if it does not exist then default to min_extrude_temp + 5
+            temp_value = [val for val in self.default_material_temps if 'default' in val][0].split(":")[1]
+        except:
+            temp_value = self.heater.min_extrude_temp + 5
+
         using_min_value = True  # Set it true if default temp/spoolman temps are not being used
         if CUR_LANE.extruder_temp is not None:
             temp_value = CUR_LANE.extruder_temp
@@ -296,6 +305,25 @@ class afc:
             pass
         return False
 
+    cmd_UNSET_LANE_LOADED_help = "Removes active lane loaded from toolhead loaded status"
+    def cmd_UNSET_LANE_LOADED(self, gcmd):
+        """
+        Unsets current lane from AFC loaded status. Mainly this would be used if AFC thinks that there is a lane loaded into the toolhead
+        but nothing is actually loaded.
+
+        It retrieves the lane specified by the 'LANE' parameter and set the appropiate values in AFC to continue using the lane.
+
+        Usage: `UNSET_LANE_LOADED`
+        Example: `UNSET_LANE_LOADED`
+
+        Args:
+            gcmd: The G-code command object containing the parameters for the command.
+
+        Returns:
+            None
+        """
+        self.FUNCTION.unset_lane_loaded()
+
     cmd_SET_AFC_TOOLCHANGES_help = "Sets number of toolchanges for AFC to keep track of"
     def cmd_SET_AFC_TOOLCHANGES(self, gcmd):
         """
@@ -332,6 +360,8 @@ class afc:
         This function handles the manual movement of a specified lane. It retrieves the lane
         specified by the 'LANE' parameter and moves it by the distance specified by the 'DISTANCE' parameter.
 
+        Distance's lower than 200 moves extruder at short_move_speed/accel, values above 200 move extruder at long_move_speed/accel
+
         Usage: `LANE_MOVE LANE=<lane> DISTANCE=<distance>`
         Example: `LANE_MOVE LANE=lane1 DISTANCE=100`
 
@@ -346,6 +376,9 @@ class afc:
         Returns:
             None
         """
+        if self.FUNCTION.is_printing(check_movement=True):
+            self.AFC.ERROR.AFC_error("Cannot move lane while printer is printing or moving")
+            return
         lane = gcmd.get('LANE', None)
         distance = gcmd.get_float('DISTANCE', 0)
         if lane not in self.lanes:
@@ -353,9 +386,13 @@ class afc:
             return
         CUR_LANE = self.lanes[lane]
         self.current_state = State.MOVING_LANE
+
+        move_speed = CUR_LANE.long_moves_speed if distance >= 200 else CUR_LANE.short_moves_speed
+        move_accel = CUR_LANE.long_moves_accel if distance >= 200 else CUR_LANE.short_moves_accel
+
         CUR_LANE.set_load_current() # Making current is set correctly when doing lane moves
         CUR_LANE.do_enable(True)
-        CUR_LANE.move(distance, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)
+        CUR_LANE.move(distance, move_speed, move_accel, True)
         CUR_LANE.do_enable(False)
         self.current_state = State.IDLE
 
@@ -412,6 +449,9 @@ class afc:
         save_vars function saves lane variables to var file and prints with indents to
                   make it more readable for users
         """
+
+        # Return early if prep is not done so that file is not overridden until prep is atleast done
+        if not self.prep_done: return
         str = {}
         for UNIT in self.units.keys():
             CUR_UNIT=self.units[UNIT]
@@ -455,6 +495,11 @@ class afc:
         Returns:
             None
         """
+
+        if self.FUNCTION.is_printing(check_movement=True):
+            self.AFC.ERROR.AFC_error("Cannot load lane to hub while printer is printing or moving")
+            return
+
         lane = gcmd.get('LANE', None)
         if lane not in self.lanes:
             self.gcode.respond_info('{} Unknown'.format(lane))
@@ -495,6 +540,10 @@ class afc:
         Returns:
             None
         """
+        if self.FUNCTION.is_printing(check_movement=True):
+            self.AFC.ERROR.AFC_error("Cannot eject lane while printer is printing or moving")
+            return
+
         lane = gcmd.get('LANE', None)
         if lane not in self.lanes:
             self.gcode.respond_info('{} Unknown'.format(lane))
@@ -540,14 +589,16 @@ class afc:
         the lane specified by the 'LANE' parameter and calls the TOOL_LOAD method to perform
         the loading process.
 
-        Usage: `TOOL_LOAD LANE=<lane>`
-        Example: `TOOL_LOAD LANE=lane1`
+        Optionally setting PURGE_LENGTH parameter to pass a value into poop macro.
+
+        Usage: `TOOL_LOAD LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)`
+        Example: `TOOL_LOAD LANE=lane1 PURGE_LENGTH=80`
 
         Args:
             gcmd: The G-code command object containing the parameters for the command.
                   Expected parameter:
                   - LANE: The name of the lane to be loaded.
-                  - PURGE_LENGTH: The amount of filament to poop (optional).
+                  - PURGE_LENGTH(optional): The amount of filament to poop, this value is passed into your poop macro.
 
 
         Returns:
@@ -571,22 +622,17 @@ class afc:
         This function handles the loading of a specified lane into the tool. It performs
         several checks and movements to ensure the lane is properly loaded.
 
-        Usage: `TOOL_LOAD LANE=<lane>`
-        Example: `TOOL_LOAD LANE=lane1`
+        :param CUR_LANE: The lane object to be loaded into the tool.
+        :param purge_length: Amount of filament to poop (optional).
 
-        Args:
-            CUR_LANE: The lane object to be loaded into the tool.
-            purge_length: Amount of filament to poop (optional).
-
-
-        Returns:
-            bool: True if load was successful, False if an error occurred.
+        :return bool: True if load was successful, False if an error occurred.
         """
         if not self.FUNCTION.is_homed():
             self.ERROR.AFC_error("Please home printer before doing a tool load", False)
             return False
 
         if CUR_LANE is None:
+            self.ERROR.AFC_error("No lane provided to load, not loading any lane.", pause=False)
             # Exit early if no lane is provided.
             return False
 
@@ -630,7 +676,10 @@ class afc:
                     CUR_LANE.move(CUR_LANE.short_move_dis, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel)
                 hub_attempts += 1
                 if hub_attempts > 20:
-                    message = ('PAST HUB, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL')
+                    message = 'filament did not trigger hub sensor, CHECK FILAMENT PATH\n||=====||==>--||-----||\nTRG   LOAD   HUB   TOOL.'
+                    if self.FUNCTION.in_print():
+                        message += '\n    Once issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(CUR_LANE.name, CUR_LANE.map)
+                        message += '\n    If you have to retract filament back, use LANE_MOVE macro for {}.'.format(CUR_LANE.name)
                     self.ERROR.handle_lane_failure(CUR_LANE, message)
                     return False
 
@@ -645,7 +694,12 @@ class afc:
                     tool_attempts += 1
                     CUR_LANE.move(CUR_LANE.short_move_dis, CUR_EXTRUDER.tool_load_speed, CUR_LANE.long_moves_accel)
                     if tool_attempts > 20:
-                        message = ('FAILED TO LOAD TO TOOL, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL')
+                        message = 'filament failed to trigger pre extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
+                        if self.FUNCTION.in_print():
+                            message += '\n    To resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(CUR_LANE.name)
+                            message += '\n    Manually move filament with LANE_MOVE macro for {} until filament is right before toolhead extruder gears,'.format(CUR_LANE.name)
+                            message += '\n     then load into extruder gears with extrude button in your gui of choice until some filament comes out nozzle'
+                            message += '\n    Once filament is fully loaded click resume to continue printing'
                         self.ERROR.handle_lane_failure(CUR_LANE, message)
                         return False
 
@@ -662,7 +716,11 @@ class afc:
                     self.toolhead.manual_move(pos, CUR_EXTRUDER.tool_load_speed)
                     self.toolhead.wait_moves()
                     if tool_attempts > 20:
-                        message = ('FAILED TO LOAD TO TOOL END, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL')
+                        message = 'filament failed to trigger post extruder gear toolhead sensor, CHECK FILAMENT PATH\n||=====||====||==>--||\nTRG   LOAD   HUB   TOOL'
+                        if self.FUNCTION.in_print():
+                            message += '\n    To resolve set lane loaded with `SET_LANE_LOADED LANE={}` macro.'.format(CUR_LANE.name)
+                            message += '\n    Also might be a good idea to verify that post extruder gear toolhead sensor is working.'
+                            message += '\n    Once issue is resolved click resume to continue printing'
                         self.ERROR.handle_lane_failure(CUR_LANE, message)
                         return False
 
@@ -716,11 +774,16 @@ class afc:
         else:
             # Handle errors if the hub is not clear or the lane is not ready for loading.
             if CUR_HUB.state:
-                message = ('HUB NOT CLEAR WHEN TRYING TO LOAD\n||-----||----|x|-----||\nTRG   LOAD   HUB   TOOL')
+                message = 'Hub not clear when trying to load.\n    Please check that hub does not contain broken filament and is clear'
+                if self.FUNCTION.in_print():
+                    message += '\n    Once issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(CUR_LANE.name, CUR_LANE.map)
                 self.ERROR.handle_lane_failure(CUR_LANE, message)
                 return False
             if not CUR_LANE.load_state:
-                message = ('NOT READY, LOAD TRIGGER NOT TRIGGERED\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL')
+                message = 'Current lane not loaded, LOAD TRIGGER NOT TRIGGERED\n||==>--||----||-----||\nTRG   LOAD   HUB   TOOL'
+                message += '\n    Please load lane before continuing.'
+                if self.FUNCTION.in_print():
+                    message += '\n    Once issue is resolved please manually load {} with {} macro and click resume to continue printing.'.format(CUR_LANE.name, CUR_LANE.map)
                 self.ERROR.handle_lane_failure(CUR_LANE, message)
                 return False
         return True
@@ -732,7 +795,7 @@ class afc:
         the lane specified by the 'LANE' parameter or uses the currently loaded lane if no parameter
         is provided, and calls the TOOL_UNLOAD method to perform the unloading process.
 
-        Usage: `TOOL_UNLOAD [LANE=<lane>]`
+        Usage: `TOOL_UNLOAD LANE=<lane>`
         Example: `TOOL_UNLOAD LANE=lane1`
 
         Args:
@@ -763,13 +826,9 @@ class afc:
         This function handles the unloading of a specified lane from the tool. It performs
         several checks and movements to ensure the lane is properly unloaded.
 
-        Usage: `TOOL_UNLOAD LANE=<lane>`
-        Example: `TOOL_UNLOAD LANE=lane1`
-        Args:
-            CUR_LANE: The lane object to be unloaded from the tool.
+        :param CUR_LANE: The lane object to be unloaded from the tool.
 
-        Returns:
-            bool: True if unloading was successful, False if an error occurred.
+        :return bool: True if unloading was successful, False if an error occurred.
         """
         # Check if the bypass filament sensor detects filament; if so unload filament and abort the tool load.
         if self._check_bypass(unload=True): return False
@@ -780,6 +839,7 @@ class afc:
 
         if CUR_LANE is None:
             # If no lane is provided, exit the function early with a failure.
+            self.ERROR.AFC_error("No lane is currently loaded, nothing to unload", pause=False)
             return False
 
         self.current_state  = State.UNLOADING
@@ -861,7 +921,12 @@ class afc:
                 num_tries += 1
                 if num_tries > self.tool_max_unload_attempts:
                     # Handle failure if the filament cannot be unloaded.
-                    message = ('FAILED TO UNLOAD. FILAMENT STUCK IN TOOLHEAD.')
+                    message = 'Failed to unload filament from toolhead. Filament stuck in toolhead.'
+                    if self.FUNCTION.in_print():
+                        message += "\n    Retract filament fully with retract button in gui of choice to remove from extruder gears if needed,"
+                        message += "\n      and then use LANE_MOVE to fully retract behind hub so its not triggered anymore."
+                        message += "\n    Then manually load {} with {} macro".format(self.next_lane_load, self.lanes[self.next_lane_load].map)
+                        message += "\n    Once lane is loaded click resume to continue printing"
                     self.ERROR.handle_lane_failure(CUR_LANE, message)
                     return False
                 CUR_LANE.sync_to_extruder()
@@ -898,7 +963,13 @@ class afc:
             num_tries += 1
             if num_tries > (CUR_HUB.afc_bowden_length / CUR_LANE.short_move_dis):
                 # Handle failure if the filament doesn't clear the hub.
-                message = 'HUB NOT CLEARING\n'
+                message = 'Hub is not clearing, filament may be stuck in hub'
+                message += '\n    Please check to make sure filament has not broken off and caused the sensor to stay stuck'
+                message += '\n    If you have to retract filament back, use LANE_MOVE macro for {}.'.format(CUR_LANE.name)
+                if self.FUNCTION.in_print():
+                    message += "\n    Once hub is clear, manually load {} with {} macro".format(self.next_lane_load, self.lanes[self.next_lane_load].map)
+                    message += "\n    Once lane is loaded click resume to continue printing"
+
                 self.ERROR.handle_lane_failure(CUR_LANE, message)
                 return False
 
@@ -945,14 +1016,16 @@ class afc:
         checks the filament sensor, saves the current position, and performs the tool change by unloading the
         current lane and loading the new lane.
 
-        Usage: `CHANGE_TOOL LANE=<lane>`
-        Example: `CHANGE_TOOL LANE=lane1`
+        Optionally setting PURGE_LENGTH parameter to pass a value into poop macro.
+
+        Usage: `CHANGE_TOOL LANE=<lane> PURGE_LENGTH=<purge_length>(optional value)`
+        Example: `CHANGE_TOOL LANE=lane1 PURGE_LENGTH=100`
 
         Args:
             gcmd: The G-code command object containing the parameters for the command.
                   Expected parameter:
                   - LANE: The name of the lane to be loaded.
-                  - PURGE_LENGTH: The amount of filament to poop (optional).
+                  - PURGE_LENGTH(optional): The amount of filament to poop, this value is passed into your poop macro.
 
 
         Returns:
@@ -1076,7 +1149,7 @@ class afc:
                 numoflanes +=1
                 name.append(lane.name)
             str[unit.name]['system']['type']        = unit.type
-            str[unit.name]['system']['hub_loaded']  = unit.hub_obj.state
+            str[unit.name]['system']['hub_loaded'] = unit.hub_obj.state if unit.hub_obj is not None else None
 
         str["system"]                           = {}
         str["system"]['current_load']           = self.current

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -83,9 +83,12 @@ class afcBoxTurtle(afcUnit):
                             msg +="<span class=primary--text> in ToolHead</span>"
                             if CUR_LANE.extruder_obj.tool_start == "buffer":
                                 msg += "<span class=warning--text>\n Ram sensor enabled, confirm tool is loaded</span>"
-                            self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
-                            self.AFC.FUNCTION.afc_led(CUR_LANE.led_tool_loaded, CUR_LANE.led_index)
-                            CUR_LANE.status = 'Tooled'
+
+                            if self.AFC.FUNCTION.get_current_lane() == CUR_LANE.name:
+                                self.AFC.SPOOL.set_active_spool(CUR_LANE.spool_id)
+                                self.AFC.FUNCTION.afc_led(CUR_LANE.led_tool_loaded, CUR_LANE.led_index)
+                                CUR_LANE.status = 'Tooled'
+
                             CUR_LANE.enable_buffer()
                         else:
                             if CUR_LANE.get_toolhead_sensor_state() == True:

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -97,8 +97,12 @@ class afcError:
         self.AFC.current_state = State.ERROR if state else State.IDLE
 
     def AFC_error(self, msg, pause=True):
+        import logging
+        # Print to logger since respond_raw does not write to logger
+        logging.warning(msg)
         # Handle AFC errors
-        self.AFC.gcode._respond_error( msg )
+        for line in msg.split("\n"):
+            self.AFC.gcode.respond_raw( "!! {}".format(line) )
         if pause: self.pause_print()
 
 

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -23,30 +23,31 @@ class afc_hub:
 
         # HUB Cut variables
         # Next two variables are used in AFC
-        self.cut = config.getboolean("cut", False)
-        self.cut_cmd = config.get('cut_cmd', None)
-        self.cut_servo_name = config.get('cut_servo_name', 'cut')
-        self.cut_dist = config.getfloat("cut_dist", 50)
-        self.cut_clear = config.getfloat("cut_clear", 120)
-        self.cut_min_length = config.getfloat("cut_min_length", 200)
-        self.cut_servo_pass_angle = config.getfloat("cut_servo_pass_angle", 0)
-        self.cut_servo_clip_angle = config.getfloat("cut_servo_clip_angle", 160)
-        self.cut_servo_prep_angle = config.getfloat("cut_servo_prep_angle", 75)
-        self.cut_confirm = config.getboolean("cut_confirm", 0)
+        self.cut = config.getboolean("cut", False)                                  # Set True if Hub cutter installed (e.g. Snappy)
+        self.cut_cmd = config.get('cut_cmd', None)                                  # Macro to use for cut.
+        self.cut_servo_name = config.get('cut_servo_name', 'cut')                   # Name of servo to use for cutting
+        self.cut_dist = config.getfloat("cut_dist", 50)                             # How much filament to cut off (in mm).
+        self.cut_clear = config.getfloat("cut_clear", 120)                          # How far the filament should retract back from the hub (in mm).
+        self.cut_min_length = config.getfloat("cut_min_length", 200)                # Minimum length of filament to cut off
+        self.cut_servo_pass_angle = config.getfloat("cut_servo_pass_angle", 0)      # Servo angle to align the Bowden tube with the hole for loading the toolhead.
+        self.cut_servo_clip_angle = config.getfloat("cut_servo_clip_angle", 160)    # Servo angle for cutting the filament.
+        self.cut_servo_prep_angle = config.getfloat("cut_servo_prep_angle", 75)     # Servo angle to prepare the filament for cutting (aligning the exit hole).
+        self.cut_confirm = config.getboolean("cut_confirm", 0)                      # Set True to cut filament twice
 
-        self.move_dis = config.getfloat("move_dis", 50)
+        self.move_dis = config.getfloat("move_dis", 50)                             # Distance to move the filament within the hub in mm.
 
-        self.hub_clear_move_dis = config.getfloat("hub_clear_move_dis", 25)
-        self.assisted_retract = config.getboolean("assisted_retract", False) # if True, retracts are assisted to prevent loose windings on the spool
-        self.afc_bowden_length = config.getfloat("afc_bowden_length", 900)
+        self.hub_clear_move_dis = config.getfloat("hub_clear_move_dis", 25)         # How far to move filament so that it's not block the hub exit
+        self.assisted_retract = config.getboolean("assisted_retract", False)        # if True, retracts are assisted to prevent loose windings on the spool
+        self.afc_bowden_length = config.getfloat("afc_bowden_length", 900)          # Length of the Bowden tube from the hub to the toolhead sensor in mm.
         self.config_bowden_length = self.afc_bowden_length                          # Used by SET_BOWDEN_LENGTH macro
+        self.switch_pin = config.get('switch_pin', None)                            # Pin hub sensor it connected to
+        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
+
         buttons = self.printer.load_object(config, "buttons")
-        self.switch_pin = config.get('switch_pin', None)
         if self.switch_pin is not None:
             self.state = False
             buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
 
-        self.enable_sensors_in_gui = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui)
 
         if self.enable_sensors_in_gui:
             self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -74,7 +74,9 @@ class afcPrep:
             self.AFC.tools[PrinterObject.name]=PrinterObject
             if 'system' in units:
                 # Check to see if lane_loaded is in dictionary and its its not an empty string
-                if 'lane_loaded' in units["system"]["extruders"][PrinterObject.name] and units["system"]["extruders"][PrinterObject.name]['lane_loaded']:
+                if PrinterObject.name in units["system"]["extruders"] and \
+                  'lane_loaded' in units["system"]["extruders"][PrinterObject.name] and \
+                  units["system"]["extruders"][PrinterObject.name]['lane_loaded']:
                     PrinterObject.lane_loaded = units["system"]["extruders"][PrinterObject.name]['lane_loaded']
                     self.AFC.current = PrinterObject.lane_loaded
 
@@ -86,7 +88,7 @@ class afcPrep:
             if CUR_LANE.unit in units:
                 if CUR_LANE.name in units[CUR_LANE.unit]:
                     if 'spool_id' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.spool_id = units[CUR_LANE.unit][CUR_LANE.name]['spool_id']
-                    if self.AFC.spoolman !=None and CUR_LANE.spool_id:
+                    if self.AFC.spoolman != None and CUR_LANE.spool_id:
                         self.AFC.SPOOL.set_spoolID(CUR_LANE, CUR_LANE.spool_id, save_vars=False)
                     else:
                         if 'material' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.material = units[CUR_LANE.unit][CUR_LANE.name]['material']
@@ -102,7 +104,6 @@ class afcPrep:
                     # Check for loaded_to_hub as this is how its being saved version > 1030
                     if 'loaded_to_hub' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.loaded_to_hub = units[CUR_LANE.unit][CUR_LANE.name]['loaded_to_hub']
                     if 'tool_loaded' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.tool_loaded = units[CUR_LANE.unit][CUR_LANE.name]['tool_loaded']
-                    if 'status' in units[CUR_LANE.unit][CUR_LANE.name]: CUR_LANE.status = units[CUR_LANE.unit][CUR_LANE.name]['status']
 
         for UNIT in self.AFC.units.keys():
             try: CUR_UNIT = self.AFC.units[UNIT]
@@ -143,7 +144,7 @@ class afcPrep:
         # Setting value to False so the T commands don't try to get reassigned when users manually
         #   run PREP after it has already be ran once upon boot
         self.assignTcmd = False
-
+        self.AFC.prep_done = True
         self.AFC.save_vars()
 
 def load_config(config):

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -276,8 +276,7 @@ class afcSpool:
     def cmd_SET_RUNOUT(self, gcmd):
         """
         This function handles setting the runout lane (infinite spool) for a specified lane. It retrieves the lane
-        specified by the 'LANE' parameter and updates its the lane to use if filament is empty
-        based on the information retrieved from the Spoolman API.
+        specified by the 'LANE' parameter and updates its the lane to use if filament runs out by untriggering prep sensor
 
         Usage: `SET_RUNOUT LANE=<lane> RUNOUT=<lane>`
         Example: `SET_RUNOUT LANE=lane1 RUNOUT=lane4`

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -43,8 +43,9 @@ class afcUnit:
         self.short_moves_accel  = config.getfloat("short_moves_accel",  self.AFC.short_moves_accel) # Acceleration in mm/s squared when doing short moves. Setting value here overrides values set in AFC.cfg file
         self.short_move_dis     = config.getfloat("short_move_dis",  self.AFC.short_move_dis)       # Move distance in mm for failsafe moves. Setting value here overrides values set in AFC.cfg file
         self.max_move_dis       = config.getfloat("max_move_dis", self.AFC.max_move_dis)            # Maximum distance to move filament. AFC breaks filament moves over this number into multiple moves. Useful to lower this number if running into timer too close errors when doing long filament moves. Setting value here overrides values set in AFC.cfg file
+        self.n20_break_delay_time = config.getfloat("n20_break_delay_time", self.AFC.n20_break_delay_time) # Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) and then releasing the break to allow coasting. Setting value here overrides values set in AFC.cfg file
 
-        self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload) # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
+        self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
 
     def handle_connect(self):
         """

--- a/utilities/generate_docs.py
+++ b/utilities/generate_docs.py
@@ -126,7 +126,9 @@ def main():
                 cmd_functions = extract_cmd_functions(file_path)
                 all_cmd_functions.extend(cmd_functions)
 
+    all_cmd_functions.sort(key=lambda e: e[0])
     markdown_lines = format_markdown(all_cmd_functions)
+
     write_markdown_file(markdown_lines, output_file)
 
     macros = parse_macros('../config/macros/AFC_macros.cfg')


### PR DESCRIPTION
… changes

- Updated documentation
- Added ability to manually set and unset lanes that are loaded in toolhead
- Added braking to n20 when stopping them. This was advised to implement from Isik to hopefully help reduce backfeeding from motors into MCU board when in coast mode
- Added default temperature value to default_material_temps list instead of using min_temp_val + 5
- Added check for printing for LANE_MOVE, HUB_LOAD and LANE_UNLOAD macros
- Added variable for prep done so save_vars function is not called before running prep function which would override the variables file before PREP could run
- Added more guidance to error messages when errors happen during TOOL_LOAD and TOOL_UNLOAD
- Added helper function to get loaded lane for current extruder, help move the code towards working with multiple extruders
- Added debounce logic when triggering prep sensor so that it does not run more than once
- Added variable speed to LANE_MOVE move, run faster for distance over 200
- Added printout when trying to load and load sensor is already triggered
- Added more printout to let user know when calibration is done
- Added printout when trying to unload but no lane is loaded
- Fixed error in prep when there are multiple extruders
- Fixed error when hub was not defined
- Updated generate_docs.py to sort macros in alphabetic order

## Major Changes in this PR

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
