### PR TITLE
Pause fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-03-07]
+### Added
+- Added error checking to spool runout, before if a error happened during unload it could keep running the print
+- Added lane ejection when runout detected but rollover not setup
+- Added AFC_PAUSE function to override users pause macro so that necessary measures could be added to move in Z to avoid
+  hitting part if users pause macro moves toolhead
+- Added `afc_unload_bowden_length` parameter
+- Added moving Z to previous saved position +z hop when resuming to avoid hitting part when moving back
+
+### Fixed
+- Fixed error when trying to turn of LEDs
+- Fixed saving position as it was not saving correctly
+- Reworked rollover logic to restore position after lane has been ejected fully so that nozzle does not sit
+  on part while ejecting spool
+- Fixed error where user could put wrong lane for rollover and it would not error until runout logic is triggered
+- Fixed errors found in calibration routines
+
+
 ## [2025-03-02]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once the plugin is updated, please uncomment the lines in your `printer.cfg` fil
 
 The `install-afc.sh` script will automatically install the majority of the plugin for you.
 
-Prior to starting Klipper, please review the configuration located at `~/printer_data/config/AFC/AFC_Hardware.cfg` and ensure all pins are correct for your specific hardware.
+Prior to starting Klipper, please review the configuration located at `~/printer_data/config/AFC/AFC_Turtle_(n).cfg` and ensure all pins are correct for your specific hardware.
 
 Additionally, review the following files for any changes that may be required:
 
@@ -284,7 +284,7 @@ Debug information about the respooler system can be found by visiting the follow
 
 ## LEDs not displaying correct color
 
-If your leds are not displaying the correct color update the following value under your `AFC_led` section in `~/printer_data/config/AFC/AFC_hardware.cfg` file.
+If your leds are not displaying the correct color update the following value under your `AFC_led` section in `~/printer_data/config/AFC/AFC_Turtle_(n).cfg` file.
 
 - color_order: change to match the color order for you leds. Different color orders are: RGB, RGBW, GRB, GRBW
 

--- a/docs/CONFIGURATION_OPTIONS.md
+++ b/docs/CONFIGURATION_OPTIONS.md
@@ -38,8 +38,8 @@
 - `tool_max_load_checks` (default: `4`): Max number of attempts to check to make sure filament is loaded into toolhead extruder when using buffer as ramming sensor
 - `z_hop` (default: `0`): Height to move up before and after a tool change completes
 - `xy_resume` (default: `False`): Need description or remove as this is currently an unused variable
-- `resume_speed` (default: `0`): Speed mm/s of resume move. Set to 0 to use gcode speed
-- `resume_z_speed` (default: `0`): Speed mm/s of resume move in Z. Set to 0 to use gcode speed
+- `resume_speed` (default: `25`): Speed mm/s of resume move. Set to 0 to use gcode speed
+- `resume_z_speed` (default: `25`): Speed mm/s of resume move in Z. Set to 0 to use gcode speed
 - `global_print_current` (default: `None`): Global variable to set steppers current to a specified current when printing. Going lower than 0.6 may result in TurtleNeck buffer's not working correctly
 - `enable_sensors_in_gui` (default: `False`): Set to True to show all sensor switches as filament sensors in mainsail/fluidd gui
 - `load_to_hub` (default: `True`): Fast loads filament to hub when inserted, set to False to disable. This is a global setting and can be overridden at AFC_stepper
@@ -71,6 +71,7 @@
 - `switch_pin` (default: `None`): Pin hub sensor it connected to
 - `hub_clear_move_dis` (default: `25`): How far to move filament so that it's not block the hub exit
 - `afc_bowden_length` (default: `900`): Length of the Bowden tube from the hub to the toolhead sensor in mm.
+- `afc_unload_bowden_length` (default: `afc_bowden_length`): Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
 - `assisted_retract` (default: `False`): if True, retracts are assisted to prevent loose windings on the spool
 - `move_dis` (default: `50`): Distance to move the filament within the hub in mm.
 - `cut` (default: `False`): Set True if Hub cutter installed (e.g. Snappy)

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -139,7 +139,7 @@ Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``
 
 ### SET_BOWDEN_LENGTH
 _Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
-It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified++
+It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
 by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
 it uses the hub of the current lane.  
   

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -141,7 +141,9 @@ Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``
 _Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
 It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
 by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
-it uses the hub of the current lane.  
+it uses the hub of the current lane. To reset length back to config value, pass in `reset`
+for each length to reset to value in config file. Adding +/- in front of the length will 
+increase/decrease bowden length by that amount.  
   
 Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
 Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -140,13 +140,13 @@ Example: ``SET_AFC_TOOLCHANGES TOOLCHANGES=100``
 ### SET_BOWDEN_LENGTH
 _Description_: This function adjusts the length of the Bowden tube between the hub and the toolhead.
 It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
-by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
-it uses the hub of the current lane. To reset length back to config value, pass in `reset`
-for each length to reset to value in config file. Adding +/- in front of the length will 
-increase/decrease bowden length by that amount.  
+by the 'LENGTH' parameter. UNLOAD_LENGTH adjusts unload Bowden length. If the hub is not specified
+and a lane is currently loaded, it uses the hub of the current lane. To reset length back to config
+value, pass in `reset` for each length to reset to value in config file. Adding +/- in front of the
+length will increase/decrease bowden length by that amount.  
   
-Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>``  
-Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100``  
+Usage: ``SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length> UNLOAD_LENGTH=<length>``  
+Example: ``SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=+100 UNLOAD_LENGTH=-100``  
 
 ### SET_BUFFER_VELOCITY
 _Description_: Allows users to tweak buffer velocity setting while printing. This setting is not

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -437,6 +437,18 @@ class afc:
         CUR_LANE.do_enable(False)
         self.current_state = State.IDLE
 
+    def _get_resume_speed(self):
+        """
+        Common function for return resume speed
+        """
+        return self.resume_speed if self.resume_speed > 0 else self.speed
+    
+    def _get_resume_speedz(self):
+        """
+        Common function for return resume z speed
+        """
+        return self.resume_z_speed if self.resume_z_speed > 0 else self.speed
+
     def _move_z_pos(self, z_amount):
         """
         Common function helper to move z, also does a check for max z so toolhead does not exceed max height
@@ -450,8 +462,7 @@ class afc:
         # Determine z movement, get the min value to not exceed max z movement
         newpos[2] = min(max_z, z_amount)
 
-        speedz = self.resume_z_speed if self.resume_z_speed > 0 else self.gcode_move.speed
-        self.gcode_move.move_with_transform(newpos, speedz)
+        self.gcode_move.move_with_transform(newpos, self._get_resume_speedz())
 
     def save_pos(self):
         """
@@ -496,7 +507,6 @@ class afc:
         self.gcode_move.absolute_coord = self.absolute_coord
 
         speed = self.resume_speed if self.resume_speed > 0 else self.gcode_move.speed
-        speedz = self.resume_z_speed if self.resume_z_speed > 0 else self.gcode_move.speed
         # Update GCODE STATE variables
         self.gcode_move.base_position = self.base_position
         self.gcode_move.last_position[:3] = self.last_gcode_position[:3]
@@ -512,11 +522,11 @@ class afc:
 
         # Move to previous x,y location
         newpos[:2] = self.last_gcode_position[:2]
-        self.gcode_move.move_with_transform(newpos, speed)
+        self.gcode_move.move_with_transform(newpos, self._get_resume_speed() )
 
         # Drop to previous z
         newpos[2] = self.last_gcode_position[2]
-        self.gcode_move.move_with_transform(newpos, speedz)
+        self.gcode_move.move_with_transform(newpos, self._get_resume_speedz() )
         self.current_state = State.IDLE
         self.position_saved = False
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -442,7 +442,7 @@ class afc:
         Common function for return resume speed
         """
         return self.resume_speed if self.resume_speed > 0 else self.speed
-    
+
     def _get_resume_speedz(self):
         """
         Common function for return resume z speed
@@ -506,7 +506,6 @@ class afc:
         # Restore absolute coords
         self.gcode_move.absolute_coord = self.absolute_coord
 
-        speed = self.resume_speed if self.resume_speed > 0 else self.gcode_move.speed
         # Update GCODE STATE variables
         self.gcode_move.base_position = self.base_position
         self.gcode_move.last_position[:3] = self.last_gcode_position[:3]

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -449,7 +449,7 @@ class afc:
 
         # Determine z movement, get the min value to not exceed max z movement
         newpos[2] = min(max_z, z_amount)
-        
+
         speedz = self.resume_z_speed if self.resume_z_speed > 0 else self.gcode_move.speed
         self.gcode_move.move_with_transform(newpos, speedz)
 
@@ -1238,7 +1238,7 @@ class afc:
             # Load the new lane and restore the toolhead position if successful.
             if self.TOOL_LOAD(CUR_LANE, purge_length) and not self.error_state:
                 self.afcDeltaTime.log_total_time("Total change time:")
-                if restore_pos: 
+                if restore_pos:
                     self.restore_pos()
                 self.in_toolchange = False
                 # Setting next lane load as none since toolchange was successful

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -147,11 +147,11 @@ class afcBoxTurtle(afcUnit):
 
             CUR_LANE.move(bow_pos * -1, CUR_LANE.long_moves_speed, CUR_LANE.long_moves_accel, True)
 
-            success, hub_dis, pos = self.calibrate_hub(CUR_LANE, tol)
+            success, message, hub_dis = self.calibrate_hub(CUR_LANE, tol)
 
             if not success:
-                msg = '{}'.format(hub_dis)
-                return False, msg, pos
+                msg = '{}'.format(message)
+                return False, msg, hub_dis
 
             if CUR_HUB.state:
                 # reset at hub
@@ -175,6 +175,7 @@ class afcBoxTurtle(afcUnit):
     # Helper functions for movement and calibration
     def calibrate_hub(self, CUR_LANE, tol):
         hub_pos = 0
+        msg = ''
         hub_fault_dis = CUR_LANE.dist_hub + 150
         checkpoint = 'hub calibration {}'.format(CUR_LANE.name)
         # move until hub sensor is triggered and get information
@@ -196,7 +197,7 @@ class afcBoxTurtle(afcUnit):
             return False, msg, tuned_hub_pos
 
         # when successful return values to calibration macro
-        return True, tuned_hub_pos, tuned_hub_pos
+        return True, msg, tuned_hub_pos
 
     def move_until_state(self, CUR_LANE, state, move_dis, tolerance, short_move, pos=0, fault_dis=250, checkpoint=None):
         # moves filament until specified sensor, returns values for further czlibration
@@ -284,10 +285,10 @@ class afcBoxTurtle(afcUnit):
             return False, msg, 0
 
         else:
-            success, hub_pos = self.calibrate_hub(CUR_LANE, tol)
+            success, message, hub_pos = self.calibrate_hub(CUR_LANE, tol)
 
             if not success:
-                msg = '{}'.format(hub_pos)
+                msg = '{}'.format(message)
                 return False, msg, hub_pos
 
             if CUR_HUB.state:

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -150,8 +150,7 @@ class afcBoxTurtle(afcUnit):
             success, message, hub_dis = self.calibrate_hub(CUR_LANE, tol)
 
             if not success:
-                msg = '{}'.format(message)
-                return False, msg, hub_dis
+                return False, message, hub_dis
 
             if CUR_HUB.state:
                 # reset at hub

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -287,8 +287,7 @@ class afcBoxTurtle(afcUnit):
             success, message, hub_pos = self.calibrate_hub(CUR_LANE, tol)
 
             if not success:
-                msg = '{}'.format(message)
-                return False, msg, hub_pos
+                return False, message, hub_pos
 
             if CUR_HUB.state:
                 CUR_LANE.move(CUR_HUB.move_dis * -1, CUR_LANE.short_moves_speed, CUR_LANE.short_moves_accel, True)

--- a/extras/AFC_buffer.py
+++ b/extras/AFC_buffer.py
@@ -107,6 +107,9 @@ class AFCtrigger:
 
         self.AFC.buffers[self.name] = self
 
+    def __str__(self):
+        return self.name
+
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.
 

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -169,7 +169,7 @@ class afcError:
             self.set_error_state(False)
             self.AFC.restore_pos(False)
             self.pause = False
-    
+
     cmd_AFC_RESUME_help = "Pauses print, raises z by z-hop amount, and then calls users pause macro"
     def cmd_AFC_PAUSE(self, gcmd):
         self.logger.debug("AFC_PAUSE")

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -153,11 +153,11 @@ class afcError:
         """
         # Save current pause state
         temp_is_paused = self.AFC.FUNCTION.is_paused()
-        currPos = self.AFC.toolhead.get_position()
+        curr_pos = self.AFC.toolhead.get_position()
 
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
-        if (currPos[2] <= self.AFC.last_gcode_position[2]):
+        if (curr_pos[2] <= self.AFC.last_gcode_position[2]):
             self.AFC._move_z_pos( self.AFC.last_gcode_position[2] + self.AFC.z_hop )
 
         self.logger.debug("Before User Restore")

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -53,6 +53,9 @@ class AFCextruder:
 
         self.common_save_msg = "\nRun SAVE_EXTRUDER_VALUES EXTRUDER={} once done to update values in config".format(self.name)
 
+    def __str__(self):
+        return self.name
+
     def handle_connect(self):
         """
         Handle the connection event.

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -403,6 +403,7 @@ class afcFunction:
             return
 
         calibrated = []
+        checked    = False
         # Check to make sure lane and unit is valid
         if lanes is not None and lanes != 'all' and lanes not in self.AFC.lanes:
             self.AFC.ERROR.AFC_error("'{}' is not a valid lane".format(lanes), pause=False)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -721,6 +721,28 @@ class afcFunction:
 
         self.AFC.gcode.respond_info('{} reset to hub, take nessecary action'.format(lane))
 
+    def _calc_bowden_length(self, config_length, current_length, new_length):
+        """
+        Common function to calculate bowden length for afc_bowden_length and afc_unload_bowden_length
+
+        :param config_length: Current configuration length thats in config file
+        :param current_length: Current length for bowden
+        :param new_length: New length to set, increase(+), decrease(-), or reset to config value
+
+        :returns bowden_length: Calculated bowden length value
+        """
+        bowden_length = 0.0
+
+        if new_length.lower() == 'reset':
+            bowden_length = config_length
+        else:
+            if new_length[0] in ('+', '-'):
+                bowden_value = float(new_length)
+                bowden_length = current_length + bowden_value
+            else:
+                bowden_length = float(new_length)
+        
+        return bowden_length
 
     cmd_SET_BOWDEN_LENGTH_help = "Helper to dynamically set length of bowden between hub and toolhead. Pass in HUB if using multiple box turtles"
     def cmd_SET_BOWDEN_LENGTH(self, gcmd):
@@ -728,7 +750,9 @@ class afcFunction:
         This function adjusts the length of the Bowden tube between the hub and the toolhead.
         It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
         by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
-        it uses the hub of the current lane.
+        it uses the hub of the current lane. To reset length back to config value, pass in `reset`
+        for each length to reset to value in config file. Adding +/- in front of the length will 
+        increase/decrease bowden length by that amount.
 
         Usage: `SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>`
         Example: `SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100`
@@ -737,13 +761,15 @@ class afcFunction:
             gcmd: The G-code command object containing the parameters for the command.
                   Expected parameters:
                   - HUB: The name of the hub to be adjusted (optional).
-                  - LENGTH: The length adjustment value (optional).
+                  - LENGTH: The length adjustment value for afc_bowden_length variable (optional).
+                  - UNLOAD: The length adjustment value for afc_unload_bowden_length variable (optional).
 
         Returns:
             None
         """
         hub           = gcmd.get("HUB", None )
         length_param  = gcmd.get('LENGTH', None)
+        unload_length = gcmd.get('UNLOAD', None)
 
         # If hub is not passed in try and get hub if a lane is currently loaded
         if hub is None and self.AFC.current is not None:
@@ -753,23 +779,25 @@ class afcFunction:
             self.logger.info("A lane is not loaded please specify hub to adjust bowden length")
             return
 
-        CUR_HUB = self.AFC.hubs[hub]
-        config_bowden = CUR_HUB.afc_bowden_length
+        CUR_HUB                 = self.AFC.hubs[hub]
+        cur_bowden_len          = CUR_HUB.afc_bowden_length
+        cur_unload_bowden_len   = CUR_HUB.afc_unload_bowden_length
 
-        if length_param is None or length_param.strip() == '':
-            bowden_length = CUR_HUB.config_bowden_length
-        else:
-            if length_param[0] in ('+', '-'):
-                bowden_value = float(length_param)
-                bowden_length = config_bowden + bowden_value
-            else:
-                bowden_length = float(length_param)
+        if length_param is not None:
+            CUR_HUB.afc_bowden_length = self._calc_bowden_length(CUR_HUB.config_bowden_length, cur_bowden_len, length_param)
 
-        CUR_HUB.afc_bowden_length = bowden_length
+        if unload_length is not None:
+            CUR_HUB.afc_unload_bowden_length = self._calc_bowden_length(CUR_HUB.config_unload_bowden_length, cur_unload_bowden_len, unload_length)
+
         msg =  '// Hub : {}\n'.format( hub )
+        msg += '// afc_bowden_length:\n'
         msg += '//   Config Bowden Length:   {}\n'.format(CUR_HUB.config_bowden_length)
-        msg += '//   Previous Bowden Length: {}\n'.format(config_bowden)
-        msg += '//   New Bowden Length:      {}\n'.format(bowden_length)
+        msg += '//   Previous Bowden Length: {}\n'.format(cur_bowden_len)
+        msg += '//   New Bowden Length:      {}\n'.format(CUR_HUB.afc_bowden_length)
+        msg += '// afc_unload_bowden_length:\n'
+        msg += '//   Config Bowden Length:   {}\n'.format(CUR_HUB.config_unload_bowden_length)
+        msg += '//   Previous Bowden Length: {}\n'.format(cur_unload_bowden_len)
+        msg += '//   New Bowden Length:      {}\n'.format(CUR_HUB.afc_unload_bowden_length)
         msg += '\n// TO SAVE BOWDEN LENGTH afc_bowden_length MUST BE UPDATED IN AFC_Hardware.cfg for each hub if there are multiple'
         self.logger.raw(msg)
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -719,7 +719,7 @@ class afcFunction:
         CUR_LANE.loaded_to_hub = True
         CUR_LANE.do_enable(False)
 
-        self.AFC.gcode.respond_info('{} reset to hub, take nessecary action'.format(lane))
+        self.AFC.gcode.respond_info('{} reset to hub, take necessary action'.format(lane))
 
     def _calc_bowden_length(self, config_length, current_length, new_length):
         """
@@ -741,7 +741,7 @@ class afcFunction:
                 bowden_length = current_length + bowden_value
             else:
                 bowden_length = float(new_length)
-        
+
         return bowden_length
 
     cmd_SET_BOWDEN_LENGTH_help = "Helper to dynamically set length of bowden between hub and toolhead. Pass in HUB if using multiple box turtles"
@@ -751,7 +751,7 @@ class afcFunction:
         It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
         by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
         it uses the hub of the current lane. To reset length back to config value, pass in `reset`
-        for each length to reset to value in config file. Adding +/- in front of the length will 
+        for each length to reset to value in config file. Adding +/- in front of the length will
         increase/decrease bowden length by that amount.
 
         Usage: `SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>`

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -749,27 +749,27 @@ class afcFunction:
         """
         This function adjusts the length of the Bowden tube between the hub and the toolhead.
         It retrieves the hub specified by the 'HUB' parameter and the length adjustment specified
-        by the 'LENGTH' parameter. If the hub is not specified and a lane is currently loaded,
-        it uses the hub of the current lane. To reset length back to config value, pass in `reset`
-        for each length to reset to value in config file. Adding +/- in front of the length will
-        increase/decrease bowden length by that amount.
+        by the 'LENGTH' parameter. UNLOAD_LENGTH adjusts unload Bowden length. If the hub is not specified
+        and a lane is currently loaded, it uses the hub of the current lane. To reset length back to config
+        value, pass in `reset` for each length to reset to value in config file. Adding +/- in front of the
+        length will increase/decrease bowden length by that amount.
 
-        Usage: `SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length>`
-        Example: `SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=100`
+        Usage: `SET_BOWDEN_LENGTH HUB=<hub> LENGTH=<length> UNLOAD_LENGTH=<length>`
+        Example: `SET_BOWDEN_LENGTH HUB=Turtle_1 LENGTH=+100 UNLOAD_LENGTH=-100`
 
         Args:
             gcmd: The G-code command object containing the parameters for the command.
                   Expected parameters:
                   - HUB: The name of the hub to be adjusted (optional).
                   - LENGTH: The length adjustment value for afc_bowden_length variable (optional).
-                  - UNLOAD: The length adjustment value for afc_unload_bowden_length variable (optional).
+                  - UNLOAD_LENGTH: The length adjustment value for afc_unload_bowden_length variable (optional).
 
         Returns:
             None
         """
         hub           = gcmd.get("HUB", None )
         length_param  = gcmd.get('LENGTH', None)
-        unload_length = gcmd.get('UNLOAD', None)
+        unload_length = gcmd.get('UNLOAD_LENGTH', None)
 
         # If hub is not passed in try and get hub if a lane is currently loaded
         if hub is None and self.AFC.current is not None:

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -26,6 +26,7 @@ class afc_hub:
         self.switch_pin             = config.get('switch_pin', None)                # Pin hub sensor it connected to
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
         self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
+        self.afc_unload_bowden_length= config.getfloat("afc_unload_bowden_length", self.afc_bowden_length) # Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
         self.assisted_retract       = config.getboolean("assisted_retract", False)  # if True, retracts are assisted to prevent loose windings on the spool
         self.move_dis               = config.getfloat("move_dis", 50)               # Distance to move the filament within the hub in mm.
         # Servo settings
@@ -55,6 +56,9 @@ class afc_hub:
 
         # Adding self to AFC hubs
         self.AFC.hubs[self.name]=self
+
+    def __str__(self):
+        return self.name
 
     def handle_connect(self):
         """

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -42,6 +42,7 @@ class afc_hub:
         self.cut_confirm            = config.getboolean("cut_confirm", 0)           # Set True to cut filament twice
 
         self.config_bowden_length   = self.afc_bowden_length                        # Used by SET_BOWDEN_LENGTH macro
+        self.config_unload_bowden_length = self.afc_unload_bowden_length
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.AFC.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
 
         buttons = self.printer.load_object(config, "buttons")

--- a/extras/AFC_led.py
+++ b/extras/AFC_led.py
@@ -135,7 +135,7 @@ class AFCled:
         toolhead.register_lookahead_callback(lookahead_bgfunc)
 
     def turn_off_leds(self):
-        for i in range(self.led_helper.get_led_count()):
+        for i in range(self.led_helper.led_count):
             self.led_change( i, "0,0,0,0", False)
         self.keep_leds_off = True
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -40,21 +40,23 @@ class afcPrep:
             pdesc = "Renamed builtin of '%s'" % (base_name,)
             self.AFC.gcode.register_command(rename_name, prev_cmd, desc=pdesc)
         else:
-            self.logger.info("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_name, "</span>",))
+            self.logger.debug("{}Existing command {} not found in gcode_macros{}".format("<span class=warning--text>", base_name, "</span>",))
         self.AFC.gcode.register_command(base_name, rename_macro, desc=rename_help)
 
     def _rename_macros(self):
         """
         Helper function to rename multiple macros and substitute with AFC macros.
-        - Replaces stock RESUME macro and reassigns to AFC_resume function
+        - Replaces stock RESUME macro and reassigns to AFC_RESUME function
         - Replaces stock UNLOAD macro and reassigns to TOOL_UNLOAD function. This can be disabled in AFC_prep config
+        - Replaces stock/users PAUSE macro and reassigns to AFC_PAUSE function.
         """
         # Checking to see if rename has already been done, don't want to rename again if prep was already ran
         if not self.rename_occurred:
             self.rename_occurred = True
             self._rename( self.AFC.ERROR.BASE_RESUME_NAME, self.AFC.ERROR.AFC_RENAME_RESUME_NAME, self.AFC.ERROR.cmd_AFC_RESUME, self.AFC.ERROR.cmd_AFC_RESUME_help )
+            self._rename( self.AFC.ERROR.BASE_PAUSE_NAME,  self.AFC.ERROR.AFC_RENAME_PAUSE_NAME,  self.AFC.ERROR.cmd_AFC_PAUSE,  self.AFC.ERROR.cmd_AFC_RESUME_help )
 
-            # Check to see if the user does not want to rename UNLOAD_FILAMENT macor
+            # Check to see if the user does not want to rename UNLOAD_FILAMENT macro
             if not self.dis_unload_macro:
                 self._rename( self.AFC.BASE_UNLOAD_FILAMENT,   self.AFC.RENAMED_UNLOAD_FILAMENT,      self.AFC.cmd_TOOL_UNLOAD,      self.AFC.cmd_TOOL_UNLOAD_help )
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -297,10 +297,21 @@ class afcSpool:
         if lane == None:
             self.logger.info("No LANE Defined")
             return
+
         runout = gcmd.get('RUNOUT', '')
-        if lane not in self.AFC.lanes:
-            self.logger.info('{} Unknown'.format(lane))
+        # Check to make sure runout does not equal lane
+        if lane == runout:
+            self.logger.error("Lane({}) and runout({}) cannot be the same".format(lane, runout))
             return
+        # Check to make sure specified lane exists
+        if lane not in self.AFC.lanes:
+            self.logger.error('Unknown lane: {}'.format(lane))
+            return
+        # Check to make sure specified runout lane exists as long as runout is not set as 'NONE'
+        if runout != 'NONE' and runout not in self.AFC.lanes:
+            self.logger.error('Unknown runout lane: {}'.format(runout))
+            return
+
         CUR_LANE = self.AFC.lanes[lane]
         CUR_LANE.runout_lane = runout
         self.AFC.save_vars()

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -186,7 +186,7 @@ class AFCExtruderStepper:
         self.connect_done = False
         self.prep_active = False
         self.last_prep_time = 0
-    
+
     def __str__(self):
         return self.name
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -52,6 +52,9 @@ class afcUnit:
         self.assisted_unload    = config.getboolean("assisted_unload", self.AFC.assisted_unload)    # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in AFC.cfg file
         self.unload_on_runout   = config.getboolean("unload_on_runout", self.AFC.unload_on_runout)  # When True AFC will unload lane and then pause when runout is triggered and spool to swap to is not set(infinite spool). Setting value here overrides values set in AFC.cfg file
 
+    def __str__(self):
+        return self.name
+
     def handle_connect(self):
         """
         Handles klippy:connect event, and does error checking to make sure users have hub/extruder/buffers sections if these variables are defined at the unit level


### PR DESCRIPTION
## Major Changes in this PR
Additions:
- Added `afc_unload_bowden_length` parameter
- Added error checking to infinite spool rollover, before if a error happened during unload it could keep running the print
- Added lane ejection when unload on runout is set when runouts are detected and a lane is not set for rollover
- Added AFC_PAUSE function to override users pause macro so that necessary measures could be added to move in Z to avoid
  hitting part if users pause macro moves toolhead
- Added moving Z to previous saved position +z hop when resuming to avoid hitting part when moving back
  
Fixes:
- Fixed saving position as it was not saving correctly
- Fixed error where user could put wrong lane for rollover and it would not error until runout logic is triggered
- Fixed errors found in calibration routines
- Fixed error when trying to turn of LEDs
- Reworked rollover logic to restore position after lane has been ejected fully so that nozzle does not sit on part while ejecting spool
## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
