### PR TITLE
Update for z resume, documentation and macros

### DIFF
--- a/config/AFC_Macro_Vars.cfg
+++ b/config/AFC_Macro_Vars.cfg
@@ -67,7 +67,7 @@ variable_restore_position         : False     # True = return to initial positio
 # Distance to retract prior to making the cut, this reduces wasted filament but might cause clog 
 # if set too large and/or if there are gaps in the hotend assembly 
 # *This must be less than the distance from the nozzle to the cutter
-variable_retract_length           : 30
+variable_retract_length           : 20
 
 # This can help prevent clogging of some toolheads by doing a quick tip from to reduce stringing
 variable_quick_tip_forming        : False
@@ -82,7 +82,7 @@ variable_rip_speed                : 3         # Speed mm/s
 
 # Pushback of the remaining tip from the cold end into the hotend
 # *Must be less then retract_length
-variable_pushback_length          : 25        # Distance in mm
+variable_pushback_length          : 15        # Distance in mm
 variable_pushback_dwell_time      : 20        # Time to dwell between the pushback
 
 # Safety margin for fast vs slow travel. When traveling to the pin location
@@ -107,6 +107,7 @@ variable_safe_margin_xy           : 30, 30    # Approx toolhead width +5mm, heig
 # variable_conf_name_stepper_x: "tmc2209 stepper_x"
 # variable_conf_name_stepper_y: "tmc2209 stepper_y"
 # variable_conf_name_stepper_z: "tmc2209 stepper_z"
+# variable_awd: True
 
 
 #--=================================================================================-

--- a/config/macros/AFC_macros.cfg
+++ b/config/macros/AFC_macros.cfg
@@ -1,11 +1,11 @@
 # Eject Loaded Lane
 [gcode_macro BT_TOOL_UNLOAD]
-description: Unload the currently loaded lane
+description: Unloads the currently loaded lane
 gcode:
   TOOL_UNLOAD
 
 [gcode_macro BT_CHANGE_TOOL]
-description: Switch to a new lane by ejecting the previously loaded one
+description: Switch to a new lane by ejecting the previously loaded one and then load the lane specified by LANE parameter. Lane parameter is an integer and defaults to 1. ex. `BT_CHANGE_TOOL LANE=2` 
 gcode:
   {% set lane_num = params.LANE|default(1)|int %}
   {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
@@ -13,7 +13,7 @@ gcode:
   CHANGE_TOOL LANE={stepper ~ lane_num}
 
 [gcode_macro BT_LANE_EJECT]
-description: Fully eject the filament from the lane
+description: Fully eject the filament from the lane so spool can be removed. Lane parameter is an integer and defaults to 1. ex. `BT_LANE_EJECT LANE=2`
 gcode:
   {% set lane_num = params.LANE|default(1)|int %}
   {% set stepper = printer['gcode_macro _AFC_GLOBAL_VARS'].stepper_name|string %}
@@ -21,7 +21,7 @@ gcode:
   LANE_UNLOAD LANE={stepper ~ lane_num}
 
 [gcode_macro BT_LANE_MOVE]
-description: Move the specified lane the specified amount
+description: Move the specified lane the specified amount. Lane parameter is an integer and defaults to 1. Distance parameter is and integer and defaults to 20. Distance over 200 uses long load speeds. ex `BT_LANE_MOVE LANE=2 DISTANCE=100`
 gcode:
   {% set lane_num = params.LANE|default(1)|int %}
   {% set dist = params.DISTANCE|default(20)|float %}
@@ -30,7 +30,7 @@ gcode:
   LANE_MOVE LANE={stepper ~ lane_num} DISTANCE={dist}
 
 [gcode_macro BT_RESUME]
-description: Resume the print after an error
+description: Resume the print after an error, using normal resume will also call AFC_RESUME
 gcode:
     {% if not printer.pause_resume.is_paused %}
         RESPOND MSG="Print is not paused. Resume ignored"

--- a/config/macros/Cut.cfg
+++ b/config/macros/Cut.cfg
@@ -19,6 +19,7 @@ gcode:
     {% set restore_position = vars['restore_position']|default(true)|lower == 'true' %}
     {% set cut_count = vars['cut_count']|int %}
     {% set y_cut = vars['y_cut']|default(false)|lower == 'true' %}
+    {% set awd = vars['awd']|default(false)|lower == 'true' %}
 
     {% set cut_current_x = vars['cut_current_stepper_x']|default(0)|float %}
     {% set cut_current_y = vars['cut_current_stepper_y']|default(0)|float %}
@@ -105,11 +106,17 @@ gcode:
         {% set conf_name = vars['conf_name_stepper_x']|default('tmc2209 stepper_x') %}
         {% set conf_current_x = printer.configfile.settings[conf_name].run_current|float %}
         SET_TMC_CURRENT STEPPER=stepper_x CURRENT={cut_current_x}
+        {% if awd %}
+            SET_TMC_CURRENT STEPPER=stepper_x1 CURRENT={cut_current_x}
+        {% endif %}
     {% endif %}
     {% if cut_current_y > 0 %}
         {% set conf_name = vars['conf_name_stepper_y']|default('tmc2209 stepper_y') %}
         {% set conf_current_y = printer.configfile.settings[conf_name].run_current|float %}
         SET_TMC_CURRENT STEPPER=stepper_y CURRENT={cut_current_y}
+        {% if awd %}
+            SET_TMC_CURRENT STEPPER=stepper_y1 CURRENT={cut_current_y}
+        {% endif %}
     {% endif %}
     {% if cut_current_z > 0 %}
         {% set conf_name = vars['conf_name_stepper_z']|default('tmc2209 stepper_z') %}
@@ -130,9 +137,15 @@ gcode:
     
     {% if cut_current_x > 0 %}
         SET_TMC_CURRENT STEPPER=stepper_x CURRENT={conf_current_x}
+        {% if awd %}
+            SET_TMC_CURRENT STEPPER=stepper_x1 CURRENT={conf_current_x}
+        {% endif %}
     {% endif %}
     {% if cut_current_y > 0 %}
         SET_TMC_CURRENT STEPPER=stepper_y CURRENT={conf_current_y}
+        {% if awd %}
+            SET_TMC_CURRENT STEPPER=stepper_y1 CURRENT={conf_current_y}
+        {% endif %}
     {% endif %}
     {% if cut_current_z > 0 %}
         SET_TMC_CURRENT STEPPER=stepper_z CURRENT={conf_current_z}

--- a/docs/AFC_buffer.md
+++ b/docs/AFC_buffer.md
@@ -6,7 +6,7 @@ This file describes the `AFC_buffer` module, part of the Armored Turtle Automate
 
 The `AFC_buffer` module is responsible for handling two types of buffers: [TurtleNeck](https://github.com/ArmoredTurtle/TurtleNeck), [TurtleNeck 2.0](https://github.com/ArmoredTurtle/TurtleNeck2.0) and [Annex Engineering Belay](https://github.com/Annex-Engineering/Belay). The Turtleneck buffer involves two sensors (advance and trailing), while the Belay buffer uses a single sensor to control filament movement.
 
-The buffer adjusts the filament movement based on sensor inputs and can either compress or expand to manage filament feeding properly. Each buffer type has unique configuration options and behaviors.
+The buffer adjusts rotation distance for active Box Turtle extruder(lane) based on sensor inputs and can either compress or expand to manage filament feeding properly. Each buffer type has unique configuration options and behaviors.
 
 ### Basic Functionality
 

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -13,6 +13,14 @@ allows the option to calibrate all lanes across all units.
 Usage: ``AFC_CALIBRATION``  
 Example: ``AFC_CALIBRATION``  
 
+### AFC_LANE_RESET
+_Description_: This function resets a specified lane to the hub position in the AFC system. It checks for various error conditions,
+such as whether the toolhead is loaded or whether the hub is already clear. The function moves the lane back to the
+hub based on the specified or default distances, ensuring the lane's correct state before completing the reset.  
+  
+Usage: ``LANE_RESET LANE=<lane> DISTANCE=<distance>``  
+Example: `AFC_LANE_RESET LANE=lane1`  
+
 ### AFC_RESET
 _Description_: This function opens a prompt allowing the user to select a loaded lane for reset. It displays a list of loaded lanes
 and provides a reset button for each lane. If no lanes are loaded, an informative message is displayed indicating
@@ -82,13 +90,13 @@ several checks and movements to ensure the lane is properly loaded.
 Usage: ``HUB_LOAD LANE=<lane>``  
 Example: ``HUB_LOAD LANE=lane1``  
 
-### LANE_RESET
-_Description_: This function resets a specified lane to the hub position in the AFC system. It checks for various error conditions,
-such as whether the toolhead is loaded or whether the hub is already clear. The function moves the lane back to the
-hub based on the specified or default distances, ensuring the lane's correct state before completing the reset.  
+### LANE_MOVE
+_Description_: This function handles the manual movement of a specified lane. It retrieves the lane
+specified by the 'LANE' parameter and moves it by the distance specified by the 'DISTANCE' parameter.  
+Distance's lower than 200 moves extruder at short_move_speed/accel, values above 200 move extruder at long_move_speed/accel  
   
-Usage: ``LANE_RESET LANE=<lane> DISTANCE=<distance>``  
-Example: `LANE_RESET LANE=lane1`  
+Usage: ``LANE_MOVE LANE=<lane> DISTANCE=<distance>``  
+Example: ``LANE_MOVE LANE=lane1 DISTANCE=100``  
 
 ### LANE_UNLOAD
 _Description_: This function handles the unloading of a specified lane from the extruder. It performs
@@ -362,11 +370,11 @@ the Mainsail or Fluidd web interfaces.
 ### BT_TOOL_UNLOAD
 _Description_: Unload the currently loaded lane
 ### BT_CHANGE_TOOL
-_Description_: Switch to a new lane by ejecting the previously loaded one
+_Description_: Switch to a new lane by ejecting the previously loaded one. Lane parameter is an integer and defaults to 1. ex. `BT_CHANGE_TOOL LANE=2`
 ### BT_LANE_EJECT
-_Description_: Fully eject the filament from the lane
+_Description_: Fully eject the filament from the lane. Lane parameter is an integer and defaults to 1. ex. `BT_LANE_EJECT LANE=2`
 ### BT_LANE_MOVE
-_Description_: Move the specified lane the specified amount
+_Description_: Move the specified lane the specified amount. Lane parameter is an integer and defaults to 1. Distance parameter is and integer and defaults to 20. Distance over 200 uses long load speeds. ex `BT_LANE_MOVE LANE=2 DISTANCE=100`
 ### BT_RESUME
 _Description_: Resume the print after an error
 ### BT_PREP

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -23,7 +23,7 @@ except: raise error("Error trying to import afcDeltaTime, please rerun install-a
 try: from extras.AFC_utils import add_filament_switch
 except: raise error("Error trying to import AFC_utils, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper")
 
-AFC_VERSION="1.0.5"
+AFC_VERSION="1.0.6"
 
 # Class for holding different states so its clear what all valid states are
 class State:
@@ -444,8 +444,6 @@ class afc:
                   - LANE: The name of the lane to be moved.
                   - DISTANCE: The distance to move the lane.
 
-        NO_DOC: True
-
         Returns:
             None
         """
@@ -523,6 +521,11 @@ class afc:
                 msg += " speed: {}".format(self.speed)
                 msg += " absolute_coord: {}\n".format(self.absolute_coord)
                 self.logger.debug(msg)
+            else:
+                self.FUNCTION.log_toolhead_pos("Not Saving, Error State: {}, Is Paused {}, Position_saved {}, POS: ".format(self.error_state, self.FUNCTION.is_paused(), self.position_saved ))
+        else:
+            self.FUNCTION.log_toolhead_pos("Not Saving In a toolchange, Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}, POS: ".format(
+                self.error_state, self.FUNCTION.is_paused(), self.position_saved, self.in_toolchange ))
 
     def restore_pos(self, move_z_first=True):
         """
@@ -565,7 +568,7 @@ class afc:
         self.gcode_move.base_position[3] += e_diff
         # Return to previous xyz
         self.gcode_move.move_with_transform(self.gcode_move.last_position, self._get_resume_speedz() )
-        self.FUNCTION.log_toolhead_pos("Resume final z: ")
+        self.FUNCTION.log_toolhead_pos("Resume final z, Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}, POS: ".format(self.error_state, self.FUNCTION.is_paused(), self.position_saved, self.in_toolchange ))
         self.current_state = State.IDLE
         self.position_saved = False
 
@@ -1297,6 +1300,9 @@ class afc:
             self.logger.info("{} already loaded".format(CUR_LANE.name))
             if not self.error_state and self.number_of_toolchanges != 0 and self.current_toolchange != self.number_of_toolchanges:
                 self.current_toolchange += 1
+
+        self.FUNCTION.log_toolhead_pos("Final Change Tool: Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}, POS: ".format(
+                self.error_state, self.FUNCTION.is_paused(), self.position_saved, self.in_toolchange ))
 
     def _get_message(self):
         """

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -132,9 +132,11 @@ class afcError:
         """
         Common function to reset error_state, pause, and position_saved variables
         """
+        self.logger.debug("Resetting failures")
         self.set_error_state(False)
         self.pause              = False
         self.AFC.position_saved = False
+        self.AFC.in_toolchange  = False
 
     cmd_AFC_RESUME_help = "Clear error state and restores position before resuming the print"
     def cmd_AFC_RESUME(self, gcmd):
@@ -151,6 +153,7 @@ class afcError:
         Returns:
             None
         """
+        self.AFC.in_toolchange = False
         if not self.AFC.FUNCTION.is_paused():
             self.logger.debug("AFC_RESUME: Printer not paused, not executing resume code")
             return
@@ -173,6 +176,9 @@ class afcError:
             self.set_error_state(False)
             self.AFC.restore_pos(False)
             self.pause = False
+
+        self.logger.debug("Error State: {}, Is Paused {}, Position_saved {}, in toolchange: {}".format(
+            self.AFC.error_state, self.AFC.FUNCTION.is_paused(), self.AFC.position_saved, self.AFC.in_toolchange ))
 
     cmd_AFC_RESUME_help = "Pauses print, raises z by z-hop amount, and then calls users pause macro"
     def cmd_AFC_PAUSE(self, gcmd):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -59,7 +59,7 @@ class afcFunction:
         self.AFC.gcode.register_command('AFC_CALI_FAIL'  , self.cmd_AFC_CALI_FAIL  , desc=self.cmd_AFC_CALI_FAIL_help)
         self.AFC.gcode.register_command('AFC_HAPPY_P'    , self.cmd_AFC_HAPPY_P    , desc=self.cmd_AFC_HAPPY_P_help)
         self.AFC.gcode.register_command('AFC_RESET'      , self.cmd_AFC_RESET      , desc=self.cmd_AFC_RESET_help)
-        self.AFC.gcode.register_command('AFC_LANE_RESET' , self.cmd_LANE_RESET     , desc=self.cmd_LANE_RESET_help)
+        self.AFC.gcode.register_command('AFC_LANE_RESET' , self.cmd_AFC_LANE_RESET , desc=self.cmd_AFC_LANE_RESET_help)
 
     def ConfigRewrite(self, rawsection, rawkey, rawvalue, msg=""):
         taskdone = False
@@ -643,7 +643,11 @@ class afcFunction:
         for index, LANE in enumerate(self.AFC.lanes.values()):
             if LANE.load_state:
                 button_label = "{}".format(LANE.name)
-                button_command = "AFC_LANE_RESET LANE={} DISTANCE={}".format(LANE.name, dis)
+                if dis is not None:
+                    button_command = "AFC_LANE_RESET LANE={} DISTANCE={}".format(LANE.name, dis)
+                else:
+                    button_command = "AFC_LANE_RESET LANE={}".format(LANE.name)
+
                 button_style = "primary" if index % 2 == 0 else "secondary"
                 buttons.append((button_label, button_command, button_style))
 
@@ -654,8 +658,8 @@ class afcFunction:
         prompt.create_custom_p(title, text, buttons,
                         True, None)
 
-    cmd_LANE_RESET_help = 'reset a loaded lane to hub'
-    def cmd_LANE_RESET(self, gcmd):
+    cmd_AFC_LANE_RESET_help = 'reset a loaded lane to hub'
+    def cmd_AFC_LANE_RESET(self, gcmd):
         """
         This function resets a specified lane to the hub position in the AFC system. It checks for various error conditions,
         such as whether the toolhead is loaded or whether the hub is already clear. The function moves the lane back to the

--- a/extras/AFC_hub.py
+++ b/extras/AFC_hub.py
@@ -23,7 +23,7 @@ class afc_hub:
 
         # HUB Cut variables
         # Next two variables are used in AFC
-        self.switch_pin             = config.get('switch_pin', None)                # Pin hub sensor it connected to
+        self.switch_pin             = config.get('switch_pin')                      # Pin hub sensor it connected to
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
         self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
         self.afc_unload_bowden_length= config.getfloat("afc_unload_bowden_length", self.afc_bowden_length) # Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length


### PR DESCRIPTION
- Reseting `in_toolchange` when resuming from failure, fixes problems with returning to correct z hight on the next in_toolchange
- Updating macro documentation
- Adding AWD variable to cut so increased current applies to all X motors
- Fixed issued with `AFC_reset` macro when distance was not supplied macro call would crash klipper
- Updated cut variable retract to 20 and pushback to 15

## Major Changes in this PR

## Notes to Code Reviewers

## How the changes in this PR are tested

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Sent notification to software-design channel requesting review
